### PR TITLE
397 fix badge number

### DIFF
--- a/src/app/[lang]/components/TabFilter/TabFilter.tsx
+++ b/src/app/[lang]/components/TabFilter/TabFilter.tsx
@@ -59,16 +59,19 @@ const TabFilter = ({
                   alignItems: 'center',
                 }}
               >
-                <Typography mr={2}>{tab.label}</Typography>
+                <Typography sx={{ mr: 1 }}>{tab.label}</Typography>
                 {tab.numberOfItems && (
                   <Badge
                     sx={{
                       ' .MuiBadge-badge': {
                         color: theme.palette.white,
                         backgroundColor: tab.color,
+                        position: 'initial',
+                        transform: 'initial',
                       },
                     }}
                     badgeContent={tab.numberOfItems}
+                    max={999_999}
                   />
                 )}
               </Box>


### PR DESCRIPTION
This sets the maximum badge number to 999 999 instead of 99 (afterwards it's displayed as 999999+).
It also fixes the badge being cut due to overflowing when the number is big.